### PR TITLE
Fixed issue with JsDate constructor

### DIFF
--- a/kodando-runtime/src/main/kotlin/kodando/runtime/JsDate.kt
+++ b/kodando-runtime/src/main/kotlin/kodando/runtime/JsDate.kt
@@ -13,7 +13,7 @@ external class JsDate {
 
     constructor()
 
-    constructor(milliseconds: Int)
+    constructor(milliseconds: Long)
 
     constructor(dateString: String)
 


### PR DESCRIPTION
Swapped `Int` for `Long` since it's allow creating proper dates from Kotlin